### PR TITLE
Handle colons in file paths on Windows and create a local temp dir when run inside the t/ dir

### DIFF
--- a/lib/Test/TempDir/Tiny.pm
+++ b/lib/Test/TempDir/Tiny.pm
@@ -76,12 +76,15 @@ sub _init {
     if ( -w 't' ) {
         $ROOT_DIR = catdir( $ORIGINAL_CWD, "tmp" );
     }
+    elsif ( -w '../t' ) {  #  are we running inside the t/ dir?
+        $ROOT_DIR = catdir( $ORIGINAL_CWD, "..", "tmp" );
+    }
     else {
         $ROOT_DIR = File::Temp->newdir( TMPDIR => 1 );
     }
 
     # TEST_DIR is based on .t path under ROOT_DIR
-    ( my $dirname = $0 ) =~ tr{\\/.}{_};
+    ( my $dirname = $0 ) =~ tr{:\\/.}{_};
     $TEST_DIR = catdir( $ROOT_DIR, $dirname );
 
     # If it exists from a previous run, clear it out


### PR DESCRIPTION
This pull request handles two cases:

1.  Temp folder names in the system temp folder on Windows need to remove or change the colon character from the drive path in $ROOT_DIR.  Otherwise the system throws an exception due to invalid characters.

2.  If a test using Test::TempDir::Tiny is run inside the t/ folder, e.g. in a debug session in an IDE, then generate the tmp dir in the directory above.  The current approach generates it in the system temp dir which is more effort to track down.


t/basic.t currently only checks when run from the package root directory, and does not test directory creation using t/.. or the system temp folder.  I had a go at modifying the tests to check these other cases (see other branches on my fork), but the solution which passes has most of the code replicated across three files and will likely also fail when tests are run in parallel.  Refactoring the three permutations into a loop needs the expected folder names to be adjusted due to directory creation in the first iteration, or my use of _cleanup() is incorrect.

If you have any suggestions then I'll give them a go.

I have not run the code through tidyall as I'm on Windows and it fails one of its tests.  Please let me know if anything needs changing.

Regards,
Shawn.
