### PR TITLE
Add experimental support for 5.6

### DIFF
--- a/lib/Test/TempDir/Tiny.pm
+++ b/lib/Test/TempDir/Tiny.pm
@@ -1,4 +1,4 @@
-use 5.008001;
+use 5.006002;
 use strict;
 use warnings;
 
@@ -213,8 +213,14 @@ END {
     # only clean up in original process, not children
     if ( $$ == $ORIGINAL_PID ) {
         # our clean up must run after Test::More sets $? in its END block
-        require B;
-        push @{ B::end_av()->object_2svref }, \&_cleanup;
+        if ( $] lt "5.008000" ) {
+            *Test::TempDir::Tiny::_CLEANER::DESTROY = \&_cleanup;
+            *blob = bless( {}, 'Test::TempDir::Tiny::_CLEANER' );
+        }
+        else {
+            require B;
+            push @{ B::end_av()->object_2svref }, \&_cleanup;
+        }
     }
 }
 


### PR DESCRIPTION
This is not so reliable as pushing things into the `END{}` stack,
but exploits global destruction to occur after the `exit()` call
in `Test::More::_my_exit`

Alternative ideas that seem to have the same result in local testing
include wrapping the _my_exit function in place, with the old

```perl
my $local = \&Namespace::sub;
*Namespace::sub = { .... <custom code>; $local->(@_) };
```

Idiom. But that seems way too foolhardy given the future of
Test::Builder

Assuming neither of these approaches can be done safely, I might propose a second alternative where before 5.8, the "Only evaporates on success" becomes "always evaporates like File::Temp does, unless theres an ENV Flag which forces them to always stay".

That's at least the closest subset of this functionality I think we *can* say 5.6 *will* support, and the necessity of preserving tempdirs automatically on 5.6 doesn't seem to be that important.

Additional note: this for me is presently exhibiting the following undiagnosed warning.

```
ok 10 - failing root directory was not cleaned up
Use of uninitialized value in substr at /home/perl-smoke/perl5/perlbrew/perls/perl-5.6.2/lib/5.6.2/x86_64-linux/File/Spec/Unix.pm line 185.
	eval {...} called at /home/perl-smoke/perl5/perlbrew/perls/perl-5.6.2/lib/5.6.2/x86_64-linux/File/Spec/Unix.pm line 185
	File::Spec::Unix::_tmpdir('File::Spec', undef, '/tmp') called at /home/perl-smoke/perl5/perlbrew/perls/perl-5.6.2/lib/5.6.2/x86_64-linux/File/Spec/Unix.pm line 210
	File::Spec::Unix::tmpdir('File::Spec') called at /home/perl-smoke/perl5/perlbrew/perls/perl-5.6.2/lib/5.6.2/File/Temp.pm line 1543
	File::Temp::tempdir('TMPDIR', 1, 'CLEANUP', 1) called at /tmp/Test-TempDir-Tiny-0.012b/lib/Test/TempDir/Tiny.pm line 128
	Test::TempDir::Tiny::_init() called at /tmp/Test-TempDir-Tiny-0.012b/lib/Test/TempDir/Tiny.pm line 72
	Test::TempDir::Tiny::tempdir() called at -e line 1
ok 11 - without t, tempdir is in File::Spec->tmpdir
```

Tests however pass with this patch applied, and I look forward to additional test cases that demonstrate this approach doesn't work :) 